### PR TITLE
Fixed a crash with shields

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3907,10 +3907,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 break packetswitch;
                             }
 
-                            if (type != InventoryTransactionPacket.USE_ITEM_ACTION_CLICK_BLOCK && this.isBlocking()) {
-                                this.setBlocking(false);
-                            }
-
                             if (inventory.getHeldItemIndex() != useItemData.hotbarSlot) {
                                 inventory.equipItem(useItemData.hotbarSlot);
                             }

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3907,7 +3907,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                                 break packetswitch;
                             }
 
-                            if (this.isBlocking()) {
+                            if (type != InventoryTransactionPacket.USE_ITEM_ACTION_CLICK_BLOCK && this.isBlocking()) {
                                 this.setBlocking(false);
                             }
 


### PR DESCRIPTION
Fixed a client crash and packet spam that occurs when holding down the right mouse button while using a shield.